### PR TITLE
New `lde repl`

### DIFF
--- a/packages/lde/lde.json
+++ b/packages/lde/lde.json
@@ -17,7 +17,8 @@
 			"optional": true
 		},
 		"git": { "path": "../git" },
-		"luarocks": { "path": "../luarocks" }
+		"luarocks": { "path": "../luarocks" },
+		"readline": { "path": "../readline" }
 	},
 	"features": {
 		"windows": ["winapi"]

--- a/packages/lde/src/commands/repl.lua
+++ b/packages/lde/src/commands/repl.lua
@@ -1,4 +1,6 @@
-local ansi = require("ansi")
+local ansi      = require("ansi")
+local readline  = require("readline")
+local highlight = require("readline.highlight")
 
 local lde = require("lde-core")
 local run = require("lde-core.package.run")
@@ -24,11 +26,6 @@ local function repl(_args)
 	end
 
 	local buffer = ""
-
-	local function prompt()
-		io.write(ansi.format(buffer ~= "" and "{gray}...{reset} " or "{blue}>{reset} "))
-		io.flush()
-	end
 
 	local G = setmetatable({}, { __index = _G })
 	G._ENV = G
@@ -60,16 +57,20 @@ local function repl(_args)
 		return "{\n" .. table.concat(items, ",\n") .. "\n" .. pad .. "}"
 	end
 
+	-- Rewrite `local x, y = ...` to `x, y = ...` so variables persist in G across lines.
+	local function delocal(s)
+		return (s:gsub("^%s*local%s+([%a_][%w_%s,]-)%s*=", "%1 ="))
+	end
+
 	while true do
-		prompt()
-		local line = io.read("*l")
+		local prompt = ansi.format(buffer ~= "" and "{gray}...{reset} " or "{blue}>{reset} ")
+		local line = readline.read(prompt, highlight)
 
 		if line == nil or line == "exit()" or line == "quit()" then
-			if line == nil then print("") end
 			break
 		end
 
-		buffer = buffer == "" and line or (buffer .. "\n" .. line)
+		buffer = buffer == "" and delocal(line) or (buffer .. "\n" .. delocal(line))
 
 		local chunk, err = loadstring("return " .. buffer, "repl") or loadstring(buffer, "repl")
 

--- a/packages/readline/lde.json
+++ b/packages/readline/lde.json
@@ -1,0 +1,4 @@
+{
+	"name": "readline",
+	"version": "0.1.0"
+}

--- a/packages/readline/src/highlight.lua
+++ b/packages/readline/src/highlight.lua
@@ -2,14 +2,15 @@
 -- Returns a string with ANSI color codes applied.
 -- Colors: Catppuccin Mocha
 
-local reset   = "\27[0m"
-local keyword = "\27[38;2;203;166;247m"  -- Mauve      keywords
-local str     = "\27[38;2;166;227;161m"  -- Green      strings
-local num     = "\27[38;2;250;179;135m"  -- Peach      numbers
-local comment = "\27[38;2;88;91;112m"    -- Overlay0   comments
-local op      = "\27[38;2;137;180;250m"  -- Blue        operators
-local ident   = "\27[38;2;205;214;244m"  -- Text        identifiers
+local reset    = "\27[0m"
+local keyword  = "\27[38;2;203;166;247m" -- Mauve      keywords
+local str      = "\27[38;2;166;227;161m" -- Green      strings
+local num      = "\27[38;2;250;179;135m" -- Peach      numbers
+local comment  = "\27[38;2;88;91;112m"   -- Overlay0   comments
+local op       = "\27[38;2;137;180;250m" -- Blue        operators
+local ident    = "\27[38;2;205;214;244m" -- Text        identifiers
 
+---@format disable-next
 local keywords = {
 	["and"]=1,["break"]=1,["do"]=1,["else"]=1,["elseif"]=1,
 	["end"]=1,["false"]=1,["for"]=1,["function"]=1,["goto"]=1,
@@ -29,51 +30,54 @@ local function highlight(line)
 		local c = line:sub(i, i)
 
 		-- comment
-		if line:sub(i, i+1) == "--" then
-			out[#out+1] = comment .. line:sub(i) .. reset
+		if line:sub(i, i + 1) == "--" then
+			out[#out + 1] = comment .. line:sub(i) .. reset
 			break
 
-		-- string: single or double quoted (no multiline)
+			-- string: single or double quoted (no multiline)
 		elseif c == '"' or c == "'" then
-			local q   = c
-			local j   = i + 1
+			local q = c
+			local j = i + 1
 			while j <= n do
 				local ch = line:sub(j, j)
-				if ch == "\\" then j = j + 2
-				elseif ch == q then j = j + 1; break
-				else j = j + 1 end
+				if ch == "\\" then
+					j = j + 2
+				elseif ch == q then
+					j = j + 1; break
+				else
+					j = j + 1
+				end
 			end
-			out[#out+1] = str .. line:sub(i, j-1) .. reset
+			out[#out + 1] = str .. line:sub(i, j - 1) .. reset
 			i = j
 
-		-- number
-		elseif c:match("%d") or (c == "." and line:sub(i+1,i+1):match("%d")) then
+			-- number
+		elseif c:match("%d") or (c == "." and line:sub(i + 1, i + 1):match("%d")) then
 			local j = i
 			-- hex
-			if line:sub(i, i+1):lower() == "0x" then
+			if line:sub(i, i + 1):lower() == "0x" then
 				j = i + 2
-				while j <= n and line:sub(j,j):match("[%x]") do j = j + 1 end
+				while j <= n and line:sub(j, j):match("[%x]") do j = j + 1 end
 			else
-				while j <= n and line:sub(j,j):match("[%d%.eExX_]") do j = j + 1 end
+				while j <= n and line:sub(j, j):match("[%d%.eExX_]") do j = j + 1 end
 			end
-			out[#out+1] = num .. line:sub(i, j-1) .. reset
+			out[#out + 1] = num .. line:sub(i, j - 1) .. reset
 			i = j
 
-		-- identifier or keyword
+			-- identifier or keyword
 		elseif c:match("[%a_]") then
 			local j = i
-			while j <= n and line:sub(j,j):match("[%w_]") do j = j + 1 end
-			local word = line:sub(i, j-1)
-			out[#out+1] = (keywords[word] and keyword or ident) .. word .. reset
+			while j <= n and line:sub(j, j):match("[%w_]") do j = j + 1 end
+			local word = line:sub(i, j - 1)
+			out[#out + 1] = (keywords[word] and keyword or ident) .. word .. reset
 			i = j
 
-		-- operators / punctuation
+			-- operators / punctuation
 		elseif c:match("[%+%-%*/%%^#&|~<>=%(%)%[%]{}%;:,%.%%]") then
-			out[#out+1] = op .. c .. reset
+			out[#out + 1] = op .. c .. reset
 			i = i + 1
-
 		else
-			out[#out+1] = c
+			out[#out + 1] = c
 			i = i + 1
 		end
 	end

--- a/packages/readline/src/highlight.lua
+++ b/packages/readline/src/highlight.lua
@@ -1,0 +1,84 @@
+-- Minimal Lua token highlighter.
+-- Returns a string with ANSI color codes applied.
+-- Colors: Catppuccin Mocha
+
+local reset   = "\27[0m"
+local keyword = "\27[38;2;203;166;247m"  -- Mauve      keywords
+local str     = "\27[38;2;166;227;161m"  -- Green      strings
+local num     = "\27[38;2;250;179;135m"  -- Peach      numbers
+local comment = "\27[38;2;88;91;112m"    -- Overlay0   comments
+local op      = "\27[38;2;137;180;250m"  -- Blue        operators
+local ident   = "\27[38;2;205;214;244m"  -- Text        identifiers
+
+local keywords = {
+	["and"]=1,["break"]=1,["do"]=1,["else"]=1,["elseif"]=1,
+	["end"]=1,["false"]=1,["for"]=1,["function"]=1,["goto"]=1,
+	["if"]=1,["in"]=1,["local"]=1,["nil"]=1,["not"]=1,
+	["or"]=1,["repeat"]=1,["return"]=1,["then"]=1,["true"]=1,
+	["until"]=1,["while"]=1,
+}
+
+---@param line string
+---@return string highlighted
+local function highlight(line)
+	local out = {}
+	local i   = 1
+	local n   = #line
+
+	while i <= n do
+		local c = line:sub(i, i)
+
+		-- comment
+		if line:sub(i, i+1) == "--" then
+			out[#out+1] = comment .. line:sub(i) .. reset
+			break
+
+		-- string: single or double quoted (no multiline)
+		elseif c == '"' or c == "'" then
+			local q   = c
+			local j   = i + 1
+			while j <= n do
+				local ch = line:sub(j, j)
+				if ch == "\\" then j = j + 2
+				elseif ch == q then j = j + 1; break
+				else j = j + 1 end
+			end
+			out[#out+1] = str .. line:sub(i, j-1) .. reset
+			i = j
+
+		-- number
+		elseif c:match("%d") or (c == "." and line:sub(i+1,i+1):match("%d")) then
+			local j = i
+			-- hex
+			if line:sub(i, i+1):lower() == "0x" then
+				j = i + 2
+				while j <= n and line:sub(j,j):match("[%x]") do j = j + 1 end
+			else
+				while j <= n and line:sub(j,j):match("[%d%.eExX_]") do j = j + 1 end
+			end
+			out[#out+1] = num .. line:sub(i, j-1) .. reset
+			i = j
+
+		-- identifier or keyword
+		elseif c:match("[%a_]") then
+			local j = i
+			while j <= n and line:sub(j,j):match("[%w_]") do j = j + 1 end
+			local word = line:sub(i, j-1)
+			out[#out+1] = (keywords[word] and keyword or ident) .. word .. reset
+			i = j
+
+		-- operators / punctuation
+		elseif c:match("[%+%-%*/%%^#&|~<>=%(%)%[%]{}%;:,%.%%]") then
+			out[#out+1] = op .. c .. reset
+			i = i + 1
+
+		else
+			out[#out+1] = c
+			i = i + 1
+		end
+	end
+
+	return table.concat(out)
+end
+
+return highlight

--- a/packages/readline/src/init.lua
+++ b/packages/readline/src/init.lua
@@ -35,8 +35,7 @@ function readline.edit(opts)
 
 		if ch == nil or ch == "\x04" then
 			if #line == 0 then return nil end
-
-		elseif ch == "\x03" then  -- Ctrl-C
+		elseif ch == "\x03" then -- Ctrl-C
 			write("\r\n")
 			return nil
 		elseif ch == "\r" or ch == "\n" then
@@ -101,14 +100,13 @@ function readline.edit(opts)
 			if pos < #line then
 				write("\x1b[" .. (#line - pos) .. "C"); pos = #line
 			end
-		elseif ch == "\x17" then  -- Ctrl-W: delete word before cursor
+		elseif ch == "\x17" then -- Ctrl-W: delete word before cursor
 			local i = pos
 			while i > 0 and line:sub(i, i) == " " do i = i - 1 end
 			while i > 0 and line:sub(i, i) ~= " " do i = i - 1 end
 			line = line:sub(1, i) .. line:sub(pos + 1)
 			pos  = i
 			redraw(line, pos)
-
 		elseif ch == "\x0b" then
 			line = line:sub(1, pos); redraw(line, pos)
 		elseif ch == "\x15" then
@@ -128,9 +126,11 @@ function readline.read(prompt, highlight)
 	local out = readline.edit({
 		prompt    = prompt,
 		readByte  = raw.readByte,
-		write     = function(s) io.write(s); io.flush() end,
+		write     = function(s)
+			io.write(s); io.flush()
+		end,
 		history   = history,
-		highlight = highlight,
+		highlight = highlight
 	})
 	raw.exitRaw()
 	return out

--- a/packages/readline/src/init.lua
+++ b/packages/readline/src/init.lua
@@ -1,0 +1,139 @@
+local raw = jit.os == "Windows"
+	and require("readline.raw.windows")
+	or require("readline.raw.posix")
+
+---@class readline
+local readline = {}
+
+local history = {}
+
+---@param opts { prompt: string, readByte: fun(): string?, write: fun(s: string), history: string[], highlight: (fun(s:string):string)? }
+---@return string?
+function readline.edit(opts)
+	local prompt    = opts.prompt
+	local readByte  = opts.readByte
+	local write     = opts.write
+	local hist      = opts.history
+	local highlight = opts.highlight
+
+	local function redraw(line, pos)
+		local display = highlight and highlight(line) or line
+		write("\r" .. prompt .. display .. "\x1b[K")
+		local back = #line - pos
+		if back > 0 then write("\x1b[" .. back .. "D") end
+	end
+
+	local line  = ""
+	local pos   = 0
+	local hpos  = #hist + 1
+	local saved = ""
+
+	write(prompt)
+
+	while true do
+		local ch = readByte()
+
+		if ch == nil or ch == "\x04" then
+			if #line == 0 then return nil end
+
+		elseif ch == "\x03" then  -- Ctrl-C
+			write("\r\n")
+			return nil
+		elseif ch == "\r" or ch == "\n" then
+			write("\r\n")
+			if line ~= "" then hist[#hist + 1] = line end
+			return line
+		elseif ch == "\x1b" then
+			local a = readByte()
+			if a == "[" then
+				local b = readByte()
+				if b == "A" then
+					if hpos > 1 then
+						if hpos == #hist + 1 then saved = line end
+						hpos = hpos - 1
+						line = hist[hpos]; pos = #line
+						redraw(line, pos)
+					end
+				elseif b == "B" then
+					if hpos <= #hist then
+						hpos = hpos + 1
+						line = hpos == #hist + 1 and saved or hist[hpos]
+						pos  = #line
+						redraw(line, pos)
+					end
+				elseif b == "C" then
+					if pos < #line then
+						pos = pos + 1; write("\x1b[C")
+					end
+				elseif b == "D" then
+					if pos > 0 then
+						pos = pos - 1; write("\x1b[D")
+					end
+				elseif b == "H" or b == "1" then
+					if b == "1" then readByte() end
+					if pos > 0 then
+						write("\x1b[" .. pos .. "D"); pos = 0
+					end
+				elseif b == "F" or b == "4" then
+					if b == "4" then readByte() end
+					if pos < #line then
+						write("\x1b[" .. (#line - pos) .. "C"); pos = #line
+					end
+				elseif b == "3" then
+					readByte()
+					if pos < #line then
+						line = line:sub(1, pos) .. line:sub(pos + 2)
+						redraw(line, pos)
+					end
+				end
+			end
+		elseif ch == "\x7f" or ch == "\x08" then
+			if pos > 0 then
+				line = line:sub(1, pos - 1) .. line:sub(pos + 1)
+				pos  = pos - 1
+				redraw(line, pos)
+			end
+		elseif ch == "\x01" then
+			if pos > 0 then
+				write("\x1b[" .. pos .. "D"); pos = 0
+			end
+		elseif ch == "\x05" then
+			if pos < #line then
+				write("\x1b[" .. (#line - pos) .. "C"); pos = #line
+			end
+		elseif ch == "\x17" then  -- Ctrl-W: delete word before cursor
+			local i = pos
+			while i > 0 and line:sub(i, i) == " " do i = i - 1 end
+			while i > 0 and line:sub(i, i) ~= " " do i = i - 1 end
+			line = line:sub(1, i) .. line:sub(pos + 1)
+			pos  = i
+			redraw(line, pos)
+
+		elseif ch == "\x0b" then
+			line = line:sub(1, pos); redraw(line, pos)
+		elseif ch == "\x15" then
+			line = line:sub(pos + 1); pos = 0; redraw(line, pos)
+		elseif ch >= " " then
+			line = line:sub(1, pos) .. ch .. line:sub(pos + 1)
+			pos  = pos + 1
+			redraw(line, pos)
+		end
+	end
+end
+
+---@param prompt string
+---@return string?
+function readline.read(prompt, highlight)
+	raw.enterRaw()
+	local out = readline.edit({
+		prompt    = prompt,
+		readByte  = raw.readByte,
+		write     = function(s) io.write(s); io.flush() end,
+		history   = history,
+		highlight = highlight,
+	})
+	raw.exitRaw()
+	return out
+end
+
+return readline

--- a/packages/readline/src/raw/posix.lua
+++ b/packages/readline/src/raw/posix.lua
@@ -64,9 +64,9 @@ function readline.enterRaw()
 	saved = Termios()
 	ffi.copy(saved, t, ffi.sizeof(t))
 
-	t.c_iflag = bit.band(t.c_iflag, bit.bnot(bit.bor(IXON, ICRNL)))
-	t.c_oflag = bit.band(t.c_oflag, bit.bnot(OPOST))
-	t.c_lflag = bit.band(t.c_lflag, bit.bnot(bit.bor(ECHO, ICANON, ISIG, IEXTEN)))
+	t.c_iflag     = bit.band(t.c_iflag, bit.bnot(bit.bor(IXON, ICRNL)))
+	t.c_oflag     = bit.band(t.c_oflag, bit.bnot(OPOST))
+	t.c_lflag     = bit.band(t.c_lflag, bit.bnot(bit.bor(ECHO, ICANON, ISIG, IEXTEN)))
 	t.c_cc[VMIN]  = 1
 	t.c_cc[VTIME] = 0
 	ffi.C.tcsetattr(0, TCSANOW, t)

--- a/packages/readline/src/raw/posix.lua
+++ b/packages/readline/src/raw/posix.lua
@@ -1,0 +1,100 @@
+local ffi = require("ffi")
+
+-- termios layout differs between Linux and macOS
+if jit.os == "OSX" then
+	ffi.cdef([[
+		struct termios {
+			unsigned long  c_iflag;
+			unsigned long  c_oflag;
+			unsigned long  c_cflag;
+			unsigned long  c_lflag;
+			uint8_t        c_cc[20];
+			unsigned long  c_ispeed;
+			unsigned long  c_ospeed;
+		};
+	]])
+else
+	ffi.cdef([[
+		struct termios {
+			uint32_t c_iflag;
+			uint32_t c_oflag;
+			uint32_t c_cflag;
+			uint32_t c_lflag;
+			uint8_t  c_line;
+			uint8_t  c_cc[32];
+			uint32_t c_ispeed;
+			uint32_t c_ospeed;
+		};
+	]])
+end
+
+ffi.cdef([[
+	int tcgetattr(int fd, struct termios *t);
+	int tcsetattr(int fd, int action, const struct termios *t);
+	int tcflush(int fd, int queue);
+	struct winsize { uint16_t ws_row; uint16_t ws_col; uint16_t ws_xpixel; uint16_t ws_ypixel; };
+	int ioctl(int fd, unsigned long req, ...);
+]])
+
+local TCSANOW    = 0
+local ECHO       = 0x8
+local ICANON     = 0x2
+local ISIG       = 0x1
+local IXON       = 0x400
+local IEXTEN     = jit.os == "OSX" and 0x400 or 0x8000
+local ICRNL      = 0x100
+local OPOST      = 0x1
+-- TIOCGWINSZ: Linux=0x5413, macOS=0x40087468
+local TIOCGWINSZ = jit.os == "OSX" and 0x40087468 or 0x5413
+-- c_cc indices: Linux VTIME=5 VMIN=6, macOS VTIME=17 VMIN=16
+local VTIME      = jit.os == "OSX" and 17 or 5
+local VMIN       = jit.os == "OSX" and 16 or 6
+
+local Termios    = ffi.typeof("struct termios")
+local Winsize    = ffi.typeof("struct winsize")
+
+---@class readline.raw.posix
+local readline   = {}
+
+local saved      = nil
+
+function readline.enterRaw()
+	local t = Termios()
+	ffi.C.tcgetattr(0, t)
+	saved = Termios()
+	ffi.copy(saved, t, ffi.sizeof(t))
+
+	t.c_iflag = bit.band(t.c_iflag, bit.bnot(bit.bor(IXON, ICRNL)))
+	t.c_oflag = bit.band(t.c_oflag, bit.bnot(OPOST))
+	t.c_lflag = bit.band(t.c_lflag, bit.bnot(bit.bor(ECHO, ICANON, ISIG, IEXTEN)))
+	t.c_cc[VMIN]  = 1
+	t.c_cc[VTIME] = 0
+	ffi.C.tcsetattr(0, TCSANOW, t)
+end
+
+function readline.exitRaw()
+	if saved then
+		ffi.C.tcflush(0, 0) -- TCIFLUSH = 0, discard unread input
+		ffi.C.tcsetattr(0, TCSANOW, saved)
+		saved = nil
+	end
+end
+
+---@return number cols
+function readline.getCols()
+	local ws = Winsize()
+	if ffi.C.ioctl(1, TIOCGWINSZ, ws) == 0 then
+		return tonumber(ws.ws_col)
+	end
+	return 80
+end
+
+---@return string? # byte, or nil on EOF
+function readline.readByte()
+	local buf = ffi.new("uint8_t[1]")
+	local n = ffi.C.read(0, buf, 1)
+	if n <= 0 then return nil end
+	return string.char(buf[0])
+end
+
+return readline

--- a/packages/readline/src/raw/windows.lua
+++ b/packages/readline/src/raw/windows.lua
@@ -1,0 +1,134 @@
+local ffi = require("ffi")
+
+ffi.cdef([[
+	typedef void*    HANDLE;
+	typedef uint32_t DWORD;
+	typedef int      BOOL;
+	typedef uint16_t WORD;
+	typedef wchar_t  WCHAR;
+
+	typedef struct {
+		WORD X; WORD Y;
+	} COORD;
+
+	typedef struct {
+		WORD wVirtualKeyCode;
+		WORD wVirtualScanCode;
+		union { WCHAR UnicodeChar; char AsciiChar; } uChar;
+		DWORD dwControlKeyState;
+	} KEY_EVENT_RECORD;
+
+	typedef struct {
+		WORD  EventType;
+		union { KEY_EVENT_RECORD KeyEvent; } Event;
+	} INPUT_RECORD;
+
+	HANDLE GetStdHandle(DWORD nStdHandle);
+	BOOL   GetConsoleMode(HANDLE h, DWORD* mode);
+	BOOL   SetConsoleMode(HANDLE h, DWORD mode);
+	BOOL   ReadConsoleInputW(HANDLE h, INPUT_RECORD* buf, DWORD len, DWORD* read);
+	BOOL   GetConsoleScreenBufferInfo(HANDLE h, void* info);
+]])
+
+local kernel32               = ffi.load("kernel32")
+
+local STD_INPUT_HANDLE       = ffi.cast("DWORD", -10)
+local STD_OUTPUT_HANDLE      = ffi.cast("DWORD", -11)
+local ENABLE_ECHO_INPUT      = 0x0004
+local ENABLE_LINE_INPUT      = 0x0002
+local ENABLE_PROCESSED_INPUT = 0x0001
+local KEY_EVENT              = 0x0001
+-- virtual key codes
+local VK_LEFT                = 0x25
+local VK_RIGHT               = 0x26 -- actually 0x27, see below
+local VK_UP                  = 0x26
+local VK_DOWN                = 0x28
+local VK_HOME                = 0x24
+local VK_END                 = 0x23
+local VK_BACK                = 0x08
+local VK_DELETE              = 0x2E
+local VK_RETURN              = 0x0D
+
+-- correct VK codes
+VK_LEFT                      = 0x25
+VK_UP                        = 0x26
+VK_RIGHT                     = 0x27
+VK_DOWN                      = 0x28
+
+local DwordBox               = ffi.typeof("DWORD[1]")
+local InputRecord            = ffi.typeof("INPUT_RECORD[1]")
+
+---@class readline.raw.windows
+local readline               = {}
+
+local hIn, hOut
+local savedMode              = nil
+
+function readline.enterRaw()
+	hIn        = kernel32.GetStdHandle(STD_INPUT_HANDLE)
+	hOut       = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+	local mode = DwordBox()
+	kernel32.GetConsoleMode(hIn, mode)
+	savedMode = tonumber(mode[0])
+	local newMode = bit.band(savedMode, bit.bnot(bit.bor(
+		ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT
+	)))
+	kernel32.SetConsoleMode(hIn, newMode)
+end
+
+function readline.exitRaw()
+	if savedMode and hIn then
+		kernel32.SetConsoleMode(hIn, savedMode)
+		savedMode = nil
+	end
+end
+
+function readline.getCols()
+	-- CONSOLE_SCREEN_BUFFER_INFO is 22 bytes
+	local info = ffi.new("uint8_t[22]")
+	if kernel32.GetConsoleScreenBufferInfo(hOut, info) ~= 0 then
+		-- dwSize is first field: COORD (2x WORD), srWindow at offset 10: LEFT,TOP,RIGHT,BOTTOM (4x SHORT)
+		local right = ffi.cast("int16_t*", info + 14)[0]
+		local left  = ffi.cast("int16_t*", info + 10)[0]
+		return tonumber(right - left + 1)
+	end
+	return 80
+end
+
+-- Returns a key descriptor string: printable char, or one of:
+-- "up","down","left","right","home","end","backspace","delete","enter", nil on EOF
+function readline.readByte()
+	local rec   = InputRecord()
+	local nread = DwordBox()
+	while true do
+		if kernel32.ReadConsoleInputW(hIn, rec, 1, nread) == 0 then return nil end
+		local r = rec[0]
+		if r.EventType == KEY_EVENT and r.Event.KeyEvent.wVirtualKeyCode ~= 0 then
+			local vk = tonumber(r.Event.KeyEvent.wVirtualKeyCode)
+			local ch = r.Event.KeyEvent.uChar.AsciiChar
+			if vk == VK_LEFT then
+				return "\x1b[D"
+			elseif vk == VK_RIGHT then
+				return "\x1b[C"
+			elseif vk == VK_UP then
+				return "\x1b[A"
+			elseif vk == VK_DOWN then
+				return "\x1b[B"
+			elseif vk == VK_HOME then
+				return "\x1b[H"
+			elseif vk == VK_END then
+				return "\x1b[F"
+			elseif vk == VK_BACK then
+				return "\x7f"
+			elseif vk == VK_DELETE then
+				return "\x1b[3~"
+			elseif vk == VK_RETURN then
+				return "\r"
+			elseif ch ~= "\0" then
+				return ch
+			end
+		end
+	end
+end
+
+return readline

--- a/packages/readline/tests/highlight.test.lua
+++ b/packages/readline/tests/highlight.test.lua
@@ -1,13 +1,13 @@
 local test      = require("lde-test")
 local highlight = require("readline.highlight")
 
-local reset   = "\27[0m"
-local yellow  = "\27[38;2;203;166;247m"  -- keyword (Mauve)
-local green   = "\27[38;2;166;227;161m"  -- string  (Green)
-local cyan    = "\27[38;2;250;179;135m"  -- number  (Peach)
-local gray    = "\27[38;2;88;91;112m"    -- comment (Overlay0)
-local magenta = "\27[38;2;137;180;250m"  -- op      (Blue)
-local white   = "\27[38;2;205;214;244m"  -- ident   (Text)
+local reset     = "\27[0m"
+local yellow    = "\27[38;2;203;166;247m" -- keyword (Mauve)
+local green     = "\27[38;2;166;227;161m" -- string  (Green)
+local cyan      = "\27[38;2;250;179;135m" -- number  (Peach)
+local gray      = "\27[38;2;88;91;112m" -- comment (Overlay0)
+local magenta   = "\27[38;2;137;180;250m" -- op      (Blue)
+local white     = "\27[38;2;205;214;244m" -- ident   (Text)
 
 local function strip(s)
 	return s:gsub("\27%[[%d;]*m", "")
@@ -69,9 +69,9 @@ test.it("highlight is passed through edit and does not corrupt result", function
 		highlight = highlight,
 		readByte  = function()
 			i = i + 1
-			return ({"l","o","c","a","l"," ","x","\r"})[i]
+			return ({ "l", "o", "c", "a", "l", " ", "x", "\r" })[i]
 		end,
-		write = function(s) out[#out+1] = s end,
+		write     = function(s) out[#out + 1] = s end
 	})
 	test.equal(result, "local x")
 end)

--- a/packages/readline/tests/highlight.test.lua
+++ b/packages/readline/tests/highlight.test.lua
@@ -1,0 +1,77 @@
+local test      = require("lde-test")
+local highlight = require("readline.highlight")
+
+local reset   = "\27[0m"
+local yellow  = "\27[38;2;203;166;247m"  -- keyword (Mauve)
+local green   = "\27[38;2;166;227;161m"  -- string  (Green)
+local cyan    = "\27[38;2;250;179;135m"  -- number  (Peach)
+local gray    = "\27[38;2;88;91;112m"    -- comment (Overlay0)
+local magenta = "\27[38;2;137;180;250m"  -- op      (Blue)
+local white   = "\27[38;2;205;214;244m"  -- ident   (Text)
+
+local function strip(s)
+	return s:gsub("\27%[[%d;]*m", "")
+end
+
+test.it("keywords are highlighted", function()
+	local out = highlight("if")
+	test.truthy(out:find(yellow, 1, true))
+	test.equal(strip(out), "if")
+end)
+
+test.it("identifiers are white", function()
+	local out = highlight("foo")
+	test.truthy(out:find(white, 1, true))
+	test.equal(strip(out), "foo")
+end)
+
+test.it("double-quoted strings are green", function()
+	local out = highlight('"hello"')
+	test.truthy(out:find(green, 1, true))
+	test.equal(strip(out), '"hello"')
+end)
+
+test.it("single-quoted strings are green", function()
+	local out = highlight("'hi'")
+	test.truthy(out:find(green, 1, true))
+	test.equal(strip(out), "'hi'")
+end)
+
+test.it("numbers are cyan", function()
+	local out = highlight("42")
+	test.truthy(out:find(cyan, 1, true))
+	test.equal(strip(out), "42")
+end)
+
+test.it("hex numbers are cyan", function()
+	local out = highlight("0xFF")
+	test.truthy(out:find(cyan, 1, true))
+	test.equal(strip(out), "0xFF")
+end)
+
+test.it("comments are gray", function()
+	local out = highlight("-- comment")
+	test.truthy(out:find(gray, 1, true))
+	test.equal(strip(out), "-- comment")
+end)
+
+test.it("mixed line preserves text content", function()
+	local line = "local x = 42 -- note"
+	test.equal(strip(highlight(line)), line)
+end)
+
+test.it("highlight is passed through edit and does not corrupt result", function()
+	local readline = require("readline")
+	local i, out = 0, {}
+	local result = readline.edit({
+		prompt    = "> ",
+		history   = {},
+		highlight = highlight,
+		readByte  = function()
+			i = i + 1
+			return ({"l","o","c","a","l"," ","x","\r"})[i]
+		end,
+		write = function(s) out[#out+1] = s end,
+	})
+	test.equal(result, "local x")
+end)

--- a/packages/readline/tests/readline.test.lua
+++ b/packages/readline/tests/readline.test.lua
@@ -12,19 +12,19 @@ if jit.os ~= "Windows" then
 		ffi.cdef("int isatty(int fd);")
 		if ffi.C.isatty(0) == 0 then return end
 
-		local VMIN  = jit.os == "OSX" and 16 or 6
-		local VTIME = jit.os == "OSX" and 17 or 5
+		local VMIN    = jit.os == "OSX" and 16 or 6
+		local VTIME   = jit.os == "OSX" and 17 or 5
 
 		-- capture termios after enterRaw
 		local Termios = ffi.typeof("struct termios")
-		local t = Termios()
+		local t       = Termios()
 		raw.enterRaw()
 		ffi.C.tcgetattr(0, t)
 		local vmin  = tonumber(t.c_cc[VMIN])
 		local vtime = tonumber(t.c_cc[VTIME])
 		raw.exitRaw()
 
-		test.equal(vmin,  1)
+		test.equal(vmin, 1)
 		test.equal(vtime, 0)
 	end)
 end

--- a/packages/readline/tests/readline.test.lua
+++ b/packages/readline/tests/readline.test.lua
@@ -1,0 +1,225 @@
+local test     = require("lde-test")
+local readline = require("readline")
+local ffi      = require("ffi")
+
+-- raw mode (posix only)
+
+if jit.os ~= "Windows" then
+	local raw = require("readline.raw.posix")
+
+	test.it("enterRaw sets VMIN=1 VTIME=0 and exitRaw restores", function()
+		-- only meaningful on a real TTY; skip if fd 0 is not a tty
+		ffi.cdef("int isatty(int fd);")
+		if ffi.C.isatty(0) == 0 then return end
+
+		local VMIN  = jit.os == "OSX" and 16 or 6
+		local VTIME = jit.os == "OSX" and 17 or 5
+
+		-- capture termios after enterRaw
+		local Termios = ffi.typeof("struct termios")
+		local t = Termios()
+		raw.enterRaw()
+		ffi.C.tcgetattr(0, t)
+		local vmin  = tonumber(t.c_cc[VMIN])
+		local vtime = tonumber(t.c_cc[VTIME])
+		raw.exitRaw()
+
+		test.equal(vmin,  1)
+		test.equal(vtime, 0)
+	end)
+end
+
+-- Helper: feed a sequence of byte strings, return {result, written}
+local function run(bytes, hist)
+	local i      = 0
+	local out    = {}
+	local result = readline.edit({
+		prompt   = "> ",
+		history  = hist or {},
+		readByte = function()
+			i = i + 1
+			return bytes[i]
+		end,
+		write    = function(s) out[#out + 1] = s end
+	})
+	return result, table.concat(out)
+end
+
+-- Escape sequences
+local UP    = "\x1b[A"
+local DOWN  = "\x1b[B"
+local RIGHT = "\x1b[C"
+local LEFT  = "\x1b[D"
+local HOME  = "\x1b[H"
+local END_  = "\x1b[F"
+local DEL   = "\x1b[3~"
+
+local function keys(...)
+	local t = {}
+	for _, v in ipairs({ ... }) do
+		if #v == 1 then
+			t[#t + 1] = v
+		else
+			-- escape sequence: split into individual bytes
+			for i = 1, #v do t[#t + 1] = v:sub(i, i) end
+		end
+	end
+	return t
+end
+
+-- basic input
+
+test.it("returns typed line on enter", function()
+	local result = run(keys("h", "i", "\r"))
+	test.equal(result, "hi")
+end)
+
+test.it("returns empty string on bare enter", function()
+	local result = run(keys("\r"))
+	test.equal(result, "")
+end)
+
+test.it("returns nil on Ctrl-D with empty line", function()
+	local result = run(keys("\x04"))
+	test.equal(result, nil)
+end)
+
+test.it("returns nil on Ctrl-C", function()
+	local result = run(keys("a", "b", "\x03"))
+	test.equal(result, nil)
+end)
+
+test.it("Ctrl-D on non-empty line does not exit", function()
+	local result = run(keys("a", "\x04", "\r"))
+	test.equal(result, "a")
+end)
+
+-- backspace
+
+test.it("backspace deletes last char", function()
+	local result = run(keys("a", "b", "\x7f", "\r"))
+	test.equal(result, "a")
+end)
+
+test.it("backspace at start does nothing", function()
+	local result = run(keys("\x7f", "a", "\r"))
+	test.equal(result, "a")
+end)
+
+-- cursor movement + insert
+
+test.it("left then insert puts char before cursor", function()
+	local result = run(keys("a", "c", LEFT, "b", "\r"))
+	test.equal(result, "abc")
+end)
+
+test.it("right moves cursor right", function()
+	local result = run(keys("a", "b", LEFT, LEFT, RIGHT, "x", "\r"))
+	test.equal(result, "axb")
+end)
+
+test.it("left at start does nothing", function()
+	local result = run(keys("a", LEFT, LEFT, LEFT, "b", "\r"))
+	test.equal(result, "ba")
+end)
+
+test.it("right at end does nothing", function()
+	local result = run(keys("a", RIGHT, RIGHT, "b", "\r"))
+	test.equal(result, "ab")
+end)
+
+-- home / end
+
+test.it("home moves to start", function()
+	local result = run(keys("a", "b", HOME, "x", "\r"))
+	test.equal(result, "xab")
+end)
+
+test.it("end moves to end", function()
+	local result = run(keys("a", "b", HOME, END_, "x", "\r"))
+	test.equal(result, "abx")
+end)
+
+-- Ctrl-A / Ctrl-E
+
+test.it("Ctrl-A moves to start", function()
+	local result = run(keys("a", "b", "\x01", "x", "\r"))
+	test.equal(result, "xab")
+end)
+
+test.it("Ctrl-E moves to end", function()
+	local result = run(keys("a", "b", "\x01", "\x05", "x", "\r"))
+	test.equal(result, "abx")
+end)
+
+-- Ctrl-K / Ctrl-U
+
+test.it("Ctrl-W deletes word before cursor", function()
+	local result = run(keys("foo", " ", "bar", "\x17", "\r"))
+	test.equal(result, "foo ")
+end)
+
+test.it("Ctrl-W deletes through leading spaces", function()
+	local result = run(keys("foo", "  ", "\x17", "\r"))
+	test.equal(result, "")
+end)
+
+test.it("Ctrl-K kills to end of line", function()
+	local result = run(keys("a", "b", "c", LEFT, "\x0b", "\r"))
+	test.equal(result, "ab")
+end)
+
+test.it("Ctrl-U kills to start of line", function()
+	local result = run(keys("a", "b", "c", LEFT, "\x15", "\r"))
+	test.equal(result, "c")
+end)
+
+-- delete key
+
+test.it("delete key removes char at cursor", function()
+	local result = run(keys("a", "b", LEFT, DEL, "\r"))
+	test.equal(result, "a")
+end)
+
+test.it("delete at end does nothing", function()
+	local result = run(keys("a", DEL, "\r"))
+	test.equal(result, "a")
+end)
+
+-- history
+
+test.it("up recalls previous entry", function()
+	local hist   = { "hello" }
+	local result = run(keys(UP, "\r"), hist)
+	test.equal(result, "hello")
+end)
+
+test.it("up then down restores current line", function()
+	local hist   = { "prev" }
+	local result = run(keys("n", "e", "w", UP, DOWN, "\r"), hist)
+	test.equal(result, "new")
+end)
+
+test.it("up past start stays at oldest entry", function()
+	local hist   = { "only" }
+	local result = run(keys(UP, UP, UP, "\r"), hist)
+	test.equal(result, "only")
+end)
+
+test.it("down past end stays at current line", function()
+	local hist   = { "a" }
+	local result = run(keys("x", DOWN, DOWN, "\r"), hist)
+	test.equal(result, "x")
+end)
+
+test.it("completed line is appended to history", function()
+	local hist = {}
+	run(keys("f", "o", "o", "\r"), hist)
+	test.equal(hist[1], "foo")
+end)
+
+test.it("empty line is not appended to history", function()
+	local hist = {}
+	run(keys("\r"), hist)
+	test.equal(#hist, 0)
+end)


### PR DESCRIPTION
Resolves #126 

This adds bindings to readline apis to read byte by byte, allowing for you to use arrow keys, history, and ctrl+w to delete word by word.

Additionally, adds a basic lua tokenizer and outputs highlighted code.

<img width="442" height="335" alt="image" src="https://github.com/user-attachments/assets/9ecab66b-9c20-46ab-b11d-ed04d4c736ae" />
