### PR TITLE
Add a profiler with flamegraph generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,9 +329,11 @@ This outputs `packages/lde/lde` (or `lde.exe` on Windows). To install it globall
 
 **Important:** Tests in `packages/lde/tests/` run the actual `lde` CLI binary via `env.execPath()`. If those tests fail after source changes, recompile and replace the binary first.
 
-## Profiling `lde` test suite
+## Profiling `lde` code
 
-To profile the `lde` CLI while it runs the repo-wide multi-package test suite, run the `lde` package from inside `packages/lde` and pass the top-level command through after `--`:
+You can profile an lde package with `lde run --profile` with `--flamegraph` to additionally generate a flamegraph.
+
+To profile the entire test suite running this:
 
 ```sh
 cd packages/lde

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ tests/          # Top-level integration test fixtures (e.g. some-package/)
 ```
 
 Each package has:
+
 - `src/` — source files (or `src/init.lua` as the entry point)
 - `lde.json` — package manifest
 - `lde.lock` — lockfile (auto-generated, commit this)
@@ -64,6 +65,7 @@ Each package has:
 `lde install` / `lde run` populate `target/` with symlinks (or copies for packages with a build script). Each dep is installed at `target/<alias>`.
 
 `package.path` is set to:
+
 ```
 target/?.lua
 target/?/init.lua
@@ -73,6 +75,7 @@ target/?.so  (or .dll / .dylib)
 So `require("json")` → `target/json/init.lua` → symlink to `packages/json/src/init.lua`.
 
 During `lde test`, `tests/` is also exposed as `target/tests`, so test files can do:
+
 ```lua
 local helper = require("tests.lib.something")  -- resolves to tests/lib/something.lua
 ```
@@ -88,6 +91,7 @@ local helper = require("tests.lib.something")  -- resolves to tests/lib/somethin
 ## Package API (`lde-core`)
 
 `require("lde-core")` returns a table with:
+
 - `lde.Package` — the Package class
 - `lde.Lockfile` — the Lockfile class
 - `lde.global` — global state/cache helpers
@@ -325,6 +329,17 @@ This outputs `packages/lde/lde` (or `lde.exe` on Windows). To install it globall
 
 **Important:** Tests in `packages/lde/tests/` run the actual `lde` CLI binary via `env.execPath()`. If those tests fail after source changes, recompile and replace the binary first.
 
+## Profiling `lde` test suite
+
+To profile the `lde` CLI while it runs the repo-wide multi-package test suite, run the `lde` package from inside `packages/lde` and pass the top-level command through after `--`:
+
+```sh
+cd packages/lde
+lde run --profile --flamegraph -- -C ../.. test
+```
+
+This profiles the `lde` package entrypoint itself, not just an individual test file, and runs `lde test` as if it had been started from the repo root.
+
 ## Managing Dependencies
 
 Always use `lde add` / `lde remove` instead of manually editing `lde.json`. Manual edits leave `lde.lock` out of sync and can break installs.
@@ -382,9 +397,9 @@ The project was previously named `lpm`. You may see `lpm.json` or `lpm-test` ref
 
 **Windows:** The system GCC on `windows-latest` targets msvcrt, but lj-dist's `libluajit` is built against UCRT. This causes linker errors (`undefined reference to __imp_fseeko64` etc). CI downloads [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) (a Clang/LLD MinGW-w64 toolchain targeting UCRT) and sets `SEA_CC`:
 
-| Runner | `SEA_CC` |
-|---|---|
-| `windows-latest` | `x86_64-w64-mingw32-clang` |
+| Runner           | `SEA_CC`                    |
+| ---------------- | --------------------------- |
+| `windows-latest` | `x86_64-w64-mingw32-clang`  |
 | `windows-11-arm` | `aarch64-w64-mingw32-clang` |
 
 **Android:** Android uses Bionic rather than glibc. The binary is compiled on the host using the Android NDK's clang (`aarch64-linux-android21-clang`), which links against Bionic. Tests run inside a Termux Docker container (`termux/termux-docker:aarch64` under QEMU on the ARM64 runner), which provides a matching Bionic environment.

--- a/packages/clap/src/init.lua
+++ b/packages/clap/src/init.lua
@@ -33,7 +33,7 @@ function Args:option(desiredKey)
 			else
 				local key = string.sub(raw, 3)
 
-				if key == desiredKey and self.raw[i + 1] ~= nil then
+				if key == desiredKey and self.raw[i + 1] ~= nil and self.raw[i + 1] ~= "--" then
 					local _key = table.remove(self.raw, i)
 					return table.remove(self.raw, i), i - 2
 				elseif key == "" then

--- a/packages/clap/tests/main.test.lua
+++ b/packages/clap/tests/main.test.lua
@@ -1,0 +1,21 @@
+local test = require("lde-test")
+
+local clap = require("clap")
+
+test.it("option does not consume -- as a value", function()
+	local args = clap.parse({ "--profile", "--flamegraph", "--", "--cwd", "../..", "test" })
+
+	test.truthy(args:flag("profile"))
+	test.equal(args:option("flamegraph"), nil)
+	test.equal(args:peek(), "--flamegraph")
+
+	local dash, dashPos = args:flag("")
+	test.truthy(dash)
+	test.equal(dashPos, 1)
+
+	local rest = args:drain(dashPos)
+	test.equal(rest[1], "--flamegraph")
+	test.equal(rest[2], "--cwd")
+	test.equal(rest[3], "../..")
+	test.equal(rest[4], "test")
+end)

--- a/packages/fs/tests/fs.test.lua
+++ b/packages/fs/tests/fs.test.lua
@@ -425,14 +425,13 @@ test.it("watch recursive detects creation in newly created subdirectory", functi
 	local sub = path.join(d, "newdir")
 	fs.mkdir(sub)
 
-	-- Drain the mkdir event and let the watcher register the new subdir
-	local deadline = os.clock() + 1
-	while os.clock() < deadline do w.poll() end
+	-- Block on the mkdir event so the watcher can register the new subdir
+	w.wait()
 
 	local before = #events
 	fs.write(path.join(sub, "file.txt"), "hi")
 
-	deadline = os.clock() + 1
+	local deadline = os.clock() + 1
 	while #events == before and os.clock() < deadline do
 		w.poll()
 	end

--- a/packages/json/benchmarks/src/init.lua
+++ b/packages/json/benchmarks/src/init.lua
@@ -45,9 +45,9 @@ end
 
 -- ── fixtures ──────────────────────────────────────────────────────────────────
 
-local SMALL = '{"name":"Alice","age":30,"active":true}'
+local SMALL     = '{"name":"Alice","age":30,"active":true}'
 
-local MEDIUM = json.encode({
+local MEDIUM    = json.encode({
 	users = (function()
 		local t = {}
 		for i = 1, 20 do
@@ -57,7 +57,7 @@ local MEDIUM = json.encode({
 	end)()
 })
 
-local LARGE = json.encode((function()
+local LARGE     = json.encode((function()
 	local t = {}
 	for i = 1, 500 do
 		t[i] = { id = i, name = "item" .. i, value = i * 3.14, tags = { "a", "b", "c" } }
@@ -77,41 +77,41 @@ local JSON5_SRC = [[{
 	ports: [8080, 8443,],
 }]]
 
-local SMALL_T  = json.decode(SMALL)
-local MEDIUM_T = json.decode(MEDIUM)
-local LARGE_T  = json.decode(LARGE)
-local JSON5_T  = json.decode(JSON5_SRC)
+local SMALL_T   = json.decode(SMALL)
+local MEDIUM_T  = json.decode(MEDIUM)
+local LARGE_T   = json.decode(LARGE)
+local JSON5_T   = json.decode(JSON5_SRC)
 
 -- ── run ───────────────────────────────────────────────────────────────────────
 
 ansi.printf("\n{bold}json decode{reset}")
-bench("small object (~40 B)",    function() json.decode(SMALL)     end, 5000)
-bench("medium array (~20 objs)", function() json.decode(MEDIUM)    end, 500)
-bench("large array (~500 objs)", function() json.decode(LARGE)     end, 20)
-bench("json5 with comments",     function() json.decode(JSON5_SRC) end, 2000)
+bench("small object (~40 B)", function() json.decode(SMALL) end, 5000)
+bench("medium array (~20 objs)", function() json.decode(MEDIUM) end, 500)
+bench("large array (~500 objs)", function() json.decode(LARGE) end, 20)
+bench("json5 with comments", function() json.decode(JSON5_SRC) end, 2000)
 
 ansi.printf("\n{bold}json encode{reset}")
-bench("small object",            function() json.encode(SMALL_T)  end, 5000)
-bench("medium array",            function() json.encode(MEDIUM_T) end, 500)
-bench("large array",             function() json.encode(LARGE_T)  end, 20)
-bench("json5 round-trip",        function() json.encode(JSON5_T)  end, 2000)
+bench("small object", function() json.encode(SMALL_T) end, 5000)
+bench("medium array", function() json.encode(MEDIUM_T) end, 500)
+bench("large array", function() json.encode(LARGE_T) end, 20)
+bench("json5 round-trip", function() json.encode(JSON5_T) end, 2000)
 
 ansi.printf("\n{bold}json round-trip (decode + encode){reset}")
-bench("small",  function() json.encode(json.decode(SMALL))  end, 5000)
+bench("small", function() json.encode(json.decode(SMALL)) end, 5000)
 bench("medium", function() json.encode(json.decode(MEDIUM)) end, 500)
-bench("large",  function() json.encode(json.decode(LARGE))  end, 20)
+bench("large", function() json.encode(json.decode(LARGE)) end, 20)
 
 ansi.printf("\n{bold}json decodeDocument only (zero-alloc){reset}")
-bench("small",  function() json.decodeDocument(SMALL)  end, 5000)
+bench("small", function() json.decodeDocument(SMALL) end, 5000)
 bench("medium", function() json.decodeDocument(MEDIUM) end, 500)
-bench("large",  function() json.decode(LARGE)  end, 20)
+bench("large", function() json.decodeDocument(LARGE) end, 20)
 
 ansi.printf("\n{bold}cjson decode{reset}")
-bench("small object (~40 B)",    function() cjson.decode(SMALL)  end, 5000)
+bench("small object (~40 B)", function() cjson.decode(SMALL) end, 5000)
 bench("medium array (~20 objs)", function() cjson.decode(MEDIUM) end, 500)
-bench("large array (~500 objs)", function() cjson.decode(LARGE)  end, 20)
+bench("large array (~500 objs)", function() cjson.decode(LARGE) end, 20)
 
 ansi.printf("\n{bold}cjson encode{reset}")
-bench("small object",  function() cjson.encode(cjson.decode(SMALL))  end, 5000)
-bench("medium array",  function() cjson.encode(cjson.decode(MEDIUM)) end, 500)
-bench("large array",   function() cjson.encode(cjson.decode(LARGE))  end, 20)
+bench("small object", function() cjson.encode(cjson.decode(SMALL)) end, 5000)
+bench("medium array", function() cjson.encode(cjson.decode(MEDIUM)) end, 500)
+bench("large array", function() cjson.encode(cjson.decode(LARGE)) end, 20)

--- a/packages/json/src/init.lua
+++ b/packages/json/src/init.lua
@@ -339,8 +339,6 @@ putValue    = function(tape, v, indent, level, valueStyle)
 			tape:put("Infinity")
 		elseif v == -huge then
 			tape:put("-Infinity")
-		elseif v == floor(v) then
-			tape:put(string.format("%d", v))
 		else
 			tape:put(tostring(v))
 		end
@@ -784,17 +782,17 @@ local function materialise(doc, idx)
 		end
 		return arr
 	elseif ty == TY_OBJECT then
-		local obj  = {}
-		local keys = {}
+		local obj     = {}
+		local keys    = {}
 		keyStore[obj] = keys
 		local ki      = tok.child
 		while ki ~= 0 do
-			src_s    = doc.src; src_ptr = cast(u8p, src_s); src_len = #src_s
-			local k  = tokToString(doc.toks[ki])
-			local vi = doc.toks[ki].next
-			obj[k]   = materialise(doc, vi)
+			src_s           = doc.src; src_ptr = cast(u8p, src_s); src_len = #src_s
+			local k         = tokToString(doc.toks[ki])
+			local vi        = doc.toks[ki].next
+			obj[k]          = materialise(doc, vi)
 			keys[#keys + 1] = k
-			ki = doc.toks[vi].next
+			ki              = doc.toks[vi].next
 		end
 		return obj
 	end

--- a/packages/lde-core/src/flamegraph.lua
+++ b/packages/lde-core/src/flamegraph.lua
@@ -1,0 +1,203 @@
+local fs = require("fs")
+
+local M = {}
+
+--- Build a tree from { "outerFrame;...;innerFrame" = count } folded stacks.
+function M.buildTree(stacks, rootName)
+	local root = { n = rootName or "root", v = 0, c = {} }
+
+	for stackStr, count in pairs(stacks) do
+		root.v = root.v + count
+		local node = root
+		for frame in stackStr:gmatch("([^;]+)") do
+			local child
+			for _, c in ipairs(node.c) do
+				if c.n == frame then child = c; break end
+			end
+			if not child then
+				child = { n = frame, v = 0, c = {} }
+				node.c[#node.c + 1] = child
+			end
+			child.v = child.v + count
+			node = child
+		end
+	end
+
+	return root
+end
+
+--- Minimal JSON encoder for the tree (only needs string keys n, integer v, array c).
+local function jsonStr(s)
+	return '"' .. s:gsub('\\', '\\\\'):gsub('"', '\\"'):gsub('\n', '\\n') .. '"'
+end
+
+local function jsonNode(node)
+	local s = '{"n":' .. jsonStr(node.n) .. ',"v":' .. node.v
+	if #node.c > 0 then
+		local parts = {}
+		for i, child in ipairs(node.c) do parts[i] = jsonNode(child) end
+		s = s .. ',"c":[' .. table.concat(parts, ',') .. ']'
+	end
+	return s .. '}'
+end
+
+local TEMPLATE = [==[<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Flamegraph · __TITLE__</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#111;color:#ccc;font:13px/1.4 monospace;overflow:hidden}
+#bar{display:flex;align-items:center;gap:14px;padding:8px 14px;
+     background:#1c1c1c;border-bottom:1px solid #2a2a2a;user-select:none}
+#bar h1{font-size:13px;font-weight:bold;color:#eee}
+#info{color:#666;font-size:12px}
+#back{display:none;color:#888;font-size:12px;cursor:pointer;border:none;
+      background:none;padding:2px 6px;border:1px solid #444;border-radius:3px;color:#aaa}
+#back:hover{background:#2a2a2a}
+#tt{position:fixed;background:#222;border:1px solid #444;padding:6px 10px;
+    font-size:12px;pointer-events:none;display:none;white-space:nowrap;color:#eee;
+    border-radius:3px;box-shadow:0 2px 8px #0008}
+canvas{display:block;cursor:crosshair}
+</style>
+</head>
+<body>
+<div id="bar">
+  <h1>__TITLE__</h1>
+  <span id="info"></span>
+  <button id="back">&#8592; back</button>
+</div>
+<div id="tt"></div>
+<canvas id="cv"></canvas>
+<script>
+var D=__DATA__,MS=__MS__;
+var ROOT=D,FOC=D,PATH=[],HOV=null;
+var cv=document.getElementById('cv');
+var ct=cv.getContext('2d');
+var tt=document.getElementById('tt');
+var RH=22;
+
+function clr(name){
+  if(name===FOC.n)return'#3a3a3a';
+  var h=0;for(var i=0;i<name.length;i++)h=(h*31+name.charCodeAt(i))|0;
+  return'hsl('+((h>>>0)%50+12)+',70%,42%)';
+}
+function fmt(v){var ms=v*MS;return ms<1000?'~'+ms+'ms':'~'+(ms/1000).toFixed(1)+'s';}
+function bySize(a,b){return b.v-a.v;}
+function kids(n){return(n.c||[]).slice().sort(bySize);}
+
+function resize(){
+  cv.width=window.innerWidth;
+  cv.height=window.innerHeight-document.getElementById('bar').offsetHeight;
+  draw();
+}
+
+function draw(){
+  ct.clearRect(0,0,cv.width,cv.height);
+  paint(FOC,0,cv.height-RH,cv.width);
+}
+
+function paint(node,x,y,w){
+  if(w<0.5||y+RH<0)return;
+  ct.fillStyle=node===HOV?'#ddd':clr(node.n);
+  ct.fillRect(x,y,Math.max(0,w-1),RH-1);
+  if(w>24){
+    ct.fillStyle=node===HOV?'#111':(node===FOC?'#bbb':'#fff');
+    ct.font='11px monospace';
+    var max=Math.floor((w-6)/6.4);
+    var lbl=node.n.length>max?node.n.slice(0,Math.max(1,max-1))+'\u2026':node.n;
+    ct.fillText(lbl,x+3,y+RH-6);
+  }
+  var kx=x,ks=kids(node);
+  for(var i=0;i<ks.length;i++){
+    var kw=w*ks[i].v/node.v;
+    paint(ks[i],kx,y-RH,kw);
+    kx+=kw;
+  }
+}
+
+function hit(node,x,y,w,mx,my){
+  if(w<0.5||mx<x||mx>=x+w)return null;
+  var kx=x,ks=kids(node);
+  for(var i=0;i<ks.length;i++){
+    var kw=w*ks[i].v/node.v;
+    var r=hit(ks[i],kx,y-RH,kw,mx,my);
+    if(r)return r;
+    kx+=kw;
+  }
+  return(my>=y&&my<y+RH)?node:null;
+}
+
+function gpos(e){var r=cv.getBoundingClientRect();return[e.clientX-r.left,e.clientY-r.top];}
+
+cv.addEventListener('mousemove',function(e){
+  var p=gpos(e),n=hit(FOC,0,cv.height-RH,cv.width,p[0],p[1]);
+  HOV=n;
+  if(n){
+    var pct=(n.v/ROOT.v*100).toFixed(1);
+    tt.innerHTML='<b>'+n.n+'</b>  '+pct+'%  '+fmt(n.v)
+      +'  <span style="color:#666">'+n.v+' samples</span>';
+    var tx=Math.min(e.clientX+14,window.innerWidth-280);
+    tt.style.cssText='display:block;left:'+tx+'px;top:'+(e.clientY-40)+'px';
+  }else{tt.style.display='none';}
+  draw();
+});
+
+cv.addEventListener('mouseleave',function(){HOV=null;tt.style.display='none';draw();});
+
+cv.addEventListener('click',function(e){
+  var p=gpos(e),n=hit(FOC,0,cv.height-RH,cv.width,p[0],p[1]);
+  if(!n)return;
+  if(n===FOC){if(PATH.length)FOC=PATH.pop();}
+  else{PATH.push(FOC);FOC=n;}
+  HOV=null;tt.style.display='none';
+  document.getElementById('back').style.display=PATH.length?'inline':'none';
+  resize();
+});
+
+document.getElementById('back').addEventListener('click',function(){
+  if(PATH.length)FOC=PATH.pop();
+  this.style.display=PATH.length?'inline':'none';
+  resize();
+});
+
+document.addEventListener('keydown',function(e){
+  if(e.key==='Escape'){PATH=[];FOC=ROOT;
+    document.getElementById('back').style.display='none';resize();}
+});
+
+window.addEventListener('resize',resize);
+document.getElementById('info').textContent=ROOT.v+' samples · '+fmt(ROOT.v);
+resize();
+</script>
+</body>
+</html>]==]
+
+--- Write a self-contained flamegraph HTML file.
+---@param stacks table<string, number> folded stack strings → sample count
+---@param total number total sample count
+---@param intervalMs number sampling interval in ms
+---@param path string output file path
+---@param title string? display title
+---@return boolean? ok
+---@return string? err
+function M.write(stacks, total, intervalMs, path, title)
+	if not next(stacks) then return nil, "no stack data collected" end
+
+	local root = M.buildTree(stacks, title or "root")
+	local json = jsonNode(root):gsub("</%f[a-z]", "<\\/")  -- escape </tag> sequences
+
+	local safeTitle = (title or "profile"):gsub("[%^%$%(%)%%%.%[%]%*%+%-%?]", "%%%0")
+	local html = TEMPLATE
+		:gsub("__TITLE__", safeTitle)
+		:gsub("__DATA__", (json:gsub("%%", "%%%%")))
+		:gsub("__MS__", tostring(intervalMs))
+
+	if not fs.write(path, html) then
+		return nil, "failed to write " .. path
+	end
+	return true
+end
+
+return M

--- a/packages/lde-core/src/init.lua
+++ b/packages/lde-core/src/init.lua
@@ -9,6 +9,7 @@ lde.Lockfile = require("lde-core.lockfile")
 
 lde.global = require("lde-core.global")
 lde.runtime = require("lde-core.runtime")
+lde.flamegraph = require("lde-core.flamegraph")
 
 lde.util = require("lde-core.util")
 

--- a/packages/lde-core/src/package/run.lua
+++ b/packages/lde-core/src/package/run.lua
@@ -25,14 +25,19 @@ end
 ---@param args string[]?
 ---@param vars table<string, string>?
 ---@param cwd string
-local function runFileWithLDE(package, scriptPath, args, vars, cwd)
+---@param profile boolean?
+---@param flamegraph string?
+local function runFileWithLDE(package, scriptPath, args, vars, cwd, profile, flamegraph)
 	local luaPath, luaCPath = getLuaPathsForPackage(package)
+
 	return runtime.executeFile(scriptPath, {
 		args = args,
 		env = vars,
 		cwd = cwd,
 		packagePath = luaPath,
-		packageCPath = luaCPath
+		packageCPath = luaCPath,
+		profile = profile,
+		flamegraph = flamegraph
 	})
 end
 
@@ -87,9 +92,11 @@ end
 ---@param args string[]?
 ---@param vars table<string, string>?
 ---@param cwd string?
+---@param profile boolean?
+---@param flamegraph string?
 ---@return boolean?
 ---@return string
-local function runFile(package, scriptPath, args, vars, cwd)
+local function runFile(package, scriptPath, args, vars, cwd, profile, flamegraph)
 	package:build()
 	local config = package:readConfig()
 
@@ -110,8 +117,12 @@ local function runFile(package, scriptPath, args, vars, cwd)
 	local engine = config.engine or "lde"
 	local ok, err
 	if engine == "lde" or engine == "lpm" --[[ compat ]] then
-		ok, err = runFileWithLDE(package, scriptPath, args, vars, cwd)
+		ok, err = runFileWithLDE(package, scriptPath, args, vars, cwd, profile, flamegraph)
 	else
+		if profile or flamegraph then
+			return nil, "Profiling is only supported when engine is 'lde'"
+		end
+
 		ok, err = runFileWithLuaCLI(package, scriptPath, args, vars, engine, cwd)
 	end
 

--- a/packages/lde-core/src/runtime.lua
+++ b/packages/lde-core/src/runtime.lua
@@ -1,5 +1,8 @@
 local env = require("env")
 local ffi = require("ffi")
+local profile = require("jit.profile")
+local ansi = require("ansi")
+local lde = require("lde-core")
 
 local originalCdef = ffi.cdef
 
@@ -31,6 +34,180 @@ local builtinModules = {
 ---@field preload table<string, function>?
 ---@field cwd string?
 ---@field postexec (fun(): any)?
+---@field profile boolean?
+---@field flamegraph string?
+
+--- Prints a profile report after a profiled execution.
+---@param counts table<string, number>
+---@param vmstates table<string, number>
+---@param total number
+---@param cwd string?
+---@param intervalMs number
+local function printProfileReport(counts, vmstates, total, cwd, intervalMs)
+	local function wln(s) io.write(s .. "\n") end
+
+	if total == 0 then
+		wln(ansi.format("  {yellow}Profile: no samples collected"))
+		return
+	end
+
+	local totalMs = total * intervalMs
+	local function fmtTime(ms)
+		if ms < 1000 then return string.format("~%dms", ms) end
+		return string.format("~%.1fs", ms / 1000)
+	end
+
+	local BAR_WIDTH = 20
+	local vmColors  = { N = "green", I = "yellow", C = "cyan", G = "red", J = "magenta" }
+	local vmLabels  = { N = "JIT compiled", I = "Interpreted", C = "C code", G = "GC", J = "JIT compiler" }
+	local vmOrder   = { "N", "I", "C", "G", "J" }
+
+	local function bar(n, color)
+		local filled = math.max(0, math.min(BAR_WIDTH, math.floor(n / total * BAR_WIDTH + 0.5)))
+		local s = filled > 0 and ansi.colorize(color, string.rep("█", filled)) or ""
+		local empty = BAR_WIDTH - filled
+		return empty > 0 and s .. ansi.colorize("gray", string.rep("░", empty)) or s
+	end
+
+	local function relativize(loc)
+		if cwd and loc:sub(1, #cwd + 1) == cwd .. "/" then
+			loc = loc:sub(#cwd + 2)
+		end
+		-- Strip target/<name>/ prefix (target dir contains symlinks to src/)
+		return (loc:gsub("^target/[^/]+/", ""))
+	end
+
+	local sep = ansi.colorize("gray", string.rep("─", 54))
+
+	io.write("\n")
+	wln(ansi.format("  {bold}Profile{reset} · {cyan}%s{reset} · {gray}%d samples @ %dms",
+		fmtTime(totalMs), total, intervalMs))
+	wln("  " .. sep)
+	io.write("\n")
+
+	wln(ansi.format("  {bold}VM State"))
+	for _, state in ipairs(vmOrder) do
+		local n = vmstates[state] or 0
+		if n > 0 then
+			local color = vmColors[state]
+			wln("  "
+				.. ansi.colorize(color, string.format("%-12s", vmLabels[state]))
+				.. "  " .. bar(n, color)
+				.. "  " .. ansi.colorize("gray", string.format("%5.1f%%", n / total * 100)))
+		end
+	end
+
+	io.write("\n")
+	wln(ansi.format("  {bold}Hotspots"))
+	wln("  " .. sep)
+
+	local sorted = {}
+	for loc, count in pairs(counts) do
+		sorted[#sorted + 1] = { loc = loc, count = count }
+	end
+	table.sort(sorted, function(a, b) return a.count > b.count end)
+
+	for i = 1, math.min(#sorted, 20) do
+		local e = sorted[i]
+		local pct = e.count / total * 100
+		local color = i == 1 and "red" or i <= 3 and "yellow" or "white"
+		wln("  "
+			.. ansi.colorize(color, string.format("%5.1f%%", pct))
+			.. "  " .. ansi.colorize("gray", string.format("%-7s", fmtTime(e.count * intervalMs)))
+			.. "  " .. relativize(e.loc))
+	end
+
+	io.write("\n")
+end
+
+---@param intervalMs number?
+---@param scriptName string?
+---@return (fun(): table<string, number>, table<string, number>, number, table<string, number>)?
+---@return string? err
+local function startProfiler(intervalMs, scriptName)
+	local counts = {}
+	local vmstates = {}
+	local stacks = {}
+	local total = 0
+	local mode = "li" .. tostring(intervalMs or 10)
+
+	-- Internal lde function names to skip when falling back to name-based profiling
+	local skipNames = {
+		commandHandler = true,
+		execute = true,
+		runFile = true,
+		runFileWithLDE = true,
+		executeWith = true,
+		startProfiler = true
+	}
+
+	local started, startErr = pcall(profile.start, mode, function(thread, samples, vmstate)
+		total = total + samples
+		vmstates[vmstate] = (vmstates[vmstate] or 0) + samples
+
+		if vmstate == "G" then return end
+
+		-- Hotspot key: try ZF (file:line) first. User code has a filesystem path
+		-- (contains /). This works for interpreted code; JIT-compiled frames are
+		-- invisible to F format, but those get caught by the f fallback below.
+		local key
+		local okF, locStack = pcall(profile.dumpstack, thread, "ZF;", -100)
+		if okF then
+			for frame in locStack:gmatch("([^;]+)") do
+				if frame:find("/", 1, true) then
+					key = frame -- last match = innermost user frame
+				end
+			end
+		end
+
+		-- Fallback for JIT code: f (function name) can see JIT-compiled functions
+		-- via JIT trace metadata even when F cannot.
+		if not key then
+			local okf, name = pcall(profile.dumpstack, thread, "f", 1)
+			if okf and name and name ~= "" and name ~= "?" and not skipNames[name] then
+				if name == "chunk" and scriptName then
+					name = scriptName:match("[^/\\]+$") or name
+				end
+				key = name
+			end
+		end
+
+		-- Flamegraph stack: use f; (function names) with full depth. Unlike ZF;,
+		-- f reads JIT trace metadata so it traverses both JIT and interpreted frames,
+		-- giving real call-chain depth regardless of vmstate.
+		local stackKey
+		local okFs, fnStack = pcall(profile.dumpstack, thread, "f;", -100)
+		if okFs and fnStack and fnStack ~= "" then
+			local parts = {}
+			for name in fnStack:gmatch("([^;]+)") do
+				-- Skip unknown frames, internal lde frames (lde:N, lde-core.x:N),
+				-- and C builtins that appear in the chain (pcall, xpcall).
+				if name ~= "?" and name ~= "chunk" and not skipNames[name] then
+					parts[#parts + 1] = name
+				end
+			end
+			if #parts > 0 then
+				stackKey = table.concat(parts, ";")
+			end
+		end
+
+		if key then
+			counts[key] = (counts[key] or 0) + samples
+		end
+		if stackKey then
+			stacks[stackKey] = (stacks[stackKey] or 0) + samples
+		end
+	end)
+
+	if not started then
+		return nil, tostring(startErr)
+	end
+
+	return function()
+		pcall(profile.stop)
+		return counts, vmstates, total, stacks
+	end
+end
 
 --- Clears non-builtin entries from a table, returning the saved contents.
 ---@param t table
@@ -126,13 +303,47 @@ local function executeWith(compile, opts, scriptName)
 		package.path = opts.packagePath or oldPath
 		package.cpath = opts.packageCPath or oldCPath
 
+		local stopProfiler, profilerErr
+		if opts.profile or opts.flamegraph then
+			stopProfiler, profilerErr = startProfiler(10, scriptName)
+			if not stopProfiler then
+				error("Failed to start profiler: " .. tostring(profilerErr))
+			end
+		end
+
 		local a, b, c, d, e, f
-		if opts.args then
-			arg = opts.args
-			arg[0] = scriptName
-			a, b, c, d, e, f = chunk(unpack(opts.args))
-		else
-			a, b, c, d, e, f = chunk()
+		local runOk, runErr = xpcall(function()
+			if opts.args then
+				arg = opts.args
+				arg[0] = scriptName
+				a, b, c, d, e, f = chunk(unpack(opts.args))
+			else
+				a, b, c, d, e, f = chunk()
+			end
+		end, function(err) return err end)
+
+		if stopProfiler then
+			local counts, vmstates, total, stacks = stopProfiler()
+			if opts.profile and lde.verbose then
+				printProfileReport(counts, vmstates, total, env.cwd(), 10)
+			end
+
+			if opts.flamegraph then
+				local fgTitle = scriptName and scriptName:match("[^/\\]+$")
+				local ok, err = lde.flamegraph.write(stacks, total, 10, opts.flamegraph, fgTitle)
+
+				if lde.verbose then
+					if ok then
+						ansi.printf("{cyan}Flamegraph written to %s\n", opts.flamegraph)
+					else
+						ansi.printf("{red}Flamegraph error: %s\n", err or "unknown error")
+					end
+				end
+			end
+		end
+
+		if not runOk then
+			error(runErr, 0)
 		end
 
 		if opts.postexec then

--- a/packages/lde-core/src/runtime.lua
+++ b/packages/lde-core/src/runtime.lua
@@ -4,6 +4,8 @@ local profile = require("jit.profile")
 local ansi = require("ansi")
 local lde = require("lde-core")
 
+local PROFILER_MS_PER_SAMPLE = 1
+
 local originalCdef = ffi.cdef
 
 local builtinModules = {
@@ -120,7 +122,7 @@ local function printProfileReport(counts, vmstates, total, cwd, intervalMs)
 	io.write("\n")
 end
 
----@param intervalMs number?
+---@param intervalMs number
 ---@param scriptName string?
 ---@return (fun(): table<string, number>, table<string, number>, number, table<string, number>)?
 ---@return string? err
@@ -129,7 +131,7 @@ local function startProfiler(intervalMs, scriptName)
 	local vmstates = {}
 	local stacks = {}
 	local total = 0
-	local mode = "li" .. tostring(intervalMs or 10)
+	local mode = "li" .. tostring(intervalMs)
 
 	-- Internal lde function names to skip when falling back to name-based profiling
 	local skipNames = {
@@ -305,7 +307,7 @@ local function executeWith(compile, opts, scriptName)
 
 		local stopProfiler, profilerErr
 		if opts.profile or opts.flamegraph then
-			stopProfiler, profilerErr = startProfiler(10, scriptName)
+			stopProfiler, profilerErr = startProfiler(PROFILER_MS_PER_SAMPLE, scriptName)
 			if not stopProfiler then
 				error("Failed to start profiler: " .. tostring(profilerErr))
 			end
@@ -325,12 +327,12 @@ local function executeWith(compile, opts, scriptName)
 		if stopProfiler then
 			local counts, vmstates, total, stacks = stopProfiler()
 			if opts.profile and lde.verbose then
-				printProfileReport(counts, vmstates, total, env.cwd(), 10)
+				printProfileReport(counts, vmstates, total, env.cwd(), PROFILER_MS_PER_SAMPLE)
 			end
 
 			if opts.flamegraph then
 				local fgTitle = scriptName and scriptName:match("[^/\\]+$")
-				local ok, err = lde.flamegraph.write(stacks, total, 10, opts.flamegraph, fgTitle)
+				local ok, err = lde.flamegraph.write(stacks, total, PROFILER_MS_PER_SAMPLE, opts.flamegraph, fgTitle)
 
 				if lde.verbose then
 					if ok then

--- a/packages/lde-core/tests/main.test.lua
+++ b/packages/lde-core/tests/main.test.lua
@@ -72,6 +72,23 @@ test.it("runtime.executeFile supports preloaded modules", function()
 	test.truthy(ok)
 end)
 
+test.it("runtime.executeFile supports profiling", function()
+	fs.mkdir(tmpBase)
+	local scriptPath = path.join(tmpBase, "profile.lua")
+	fs.write(scriptPath, [[
+		local s = 0
+		for i = 1, 500000 do
+			s = s + i
+		end
+		return s
+	]])
+
+	local ok, err = lde.runtime.executeFile(scriptPath, {
+		profile = true
+	})
+	test.truthy(ok)
+end)
+
 test.it("runtime.executeFile isolates globals between runs", function()
 	fs.mkdir(tmpBase)
 	local script1 = path.join(tmpBase, "global1.lua")

--- a/packages/lde-core/tests/profile.test.lua
+++ b/packages/lde-core/tests/profile.test.lua
@@ -1,0 +1,205 @@
+local test = require("lde-test")
+
+local fs   = require("fs")
+local env  = require("env")
+local path = require("path")
+
+local lde = require("lde-core")
+local fg  = require("lde-core.flamegraph")
+
+local tmpBase = path.join(env.tmpdir(), "lde-profile-tests")
+fs.rmdir(tmpBase)
+fs.mkdir(tmpBase)
+
+-- ── flamegraph.buildTree ──────────────────────────────────────────────────────
+
+test.it("buildTree: single stack produces root with one child", function()
+	local root = fg.buildTree({ ["a"] = 5 }, "root")
+	test.equal(root.n, "root")
+	test.equal(root.v, 5)
+	test.equal(#root.c, 1)
+	test.equal(root.c[1].n, "a")
+	test.equal(root.c[1].v, 5)
+end)
+
+test.it("buildTree: root value is the sum of all stack counts", function()
+	local root = fg.buildTree({ ["a"] = 3, ["b"] = 7, ["a;b"] = 2 }, "root")
+	test.equal(root.v, 12)
+end)
+
+test.it("buildTree: stacks with a shared prefix merge into the same parent", function()
+	-- Both stacks go through "outer" before diverging
+	local root = fg.buildTree({ ["outer;left"] = 4, ["outer;right"] = 6 }, "root")
+	test.equal(#root.c, 1)
+	local outer = root.c[1]
+	test.equal(outer.n, "outer")
+	test.equal(outer.v, 10)
+	test.equal(#outer.c, 2)
+	-- children may be in any order
+	local names = {}
+	for _, c in ipairs(outer.c) do names[c.n] = c.v end
+	test.equal(names["left"],  4)
+	test.equal(names["right"], 6)
+end)
+
+test.it("buildTree: deep stack produces correctly nested children", function()
+	local root = fg.buildTree({ ["a;b;c;d"] = 1 }, "root")
+	local node = root.c[1] -- a
+	test.equal(node.n, "a")
+	node = node.c[1] -- b
+	test.equal(node.n, "b")
+	node = node.c[1] -- c
+	test.equal(node.n, "c")
+	node = node.c[1] -- d
+	test.equal(node.n, "d")
+	test.equal(#node.c, 0)
+end)
+
+test.it("buildTree: same frame appearing in multiple stacks accumulates count", function()
+	local root = fg.buildTree({ ["outer;inner"] = 3, ["outer"] = 2 }, "root")
+	local outer = root.c[1]
+	test.equal(outer.n, "outer")
+	test.equal(outer.v, 5) -- 3 + 2
+	test.equal(#outer.c, 1)
+	test.equal(outer.c[1].v, 3) -- only the deeper stack contributed
+end)
+
+test.it("buildTree: uses 'root' as default root name", function()
+	local root = fg.buildTree({ ["x"] = 1 })
+	test.equal(root.n, "root")
+end)
+
+-- ── flamegraph.write ──────────────────────────────────────────────────────────
+
+test.it("write: returns error for empty stacks", function()
+	local ok, err = fg.write({}, 0, 10, path.join(tmpBase, "empty.html"))
+	test.falsy(ok)
+	test.truthy(err)
+	test.includes(err, "no stack data")
+end)
+
+test.it("write: creates an HTML file for non-empty stacks", function()
+	local outPath = path.join(tmpBase, "basic.html")
+	local ok, err = fg.write({ ["fn_a;fn_b"] = 5 }, 5, 10, outPath, "test")
+	test.truthy(ok)
+	test.falsy(err)
+	test.truthy(fs.exists(outPath))
+end)
+
+test.it("write: output contains no unsubstituted template placeholders", function()
+	local outPath = path.join(tmpBase, "placeholders.html")
+	fg.write({ ["fn_a"] = 3 }, 3, 10, outPath, "my profile")
+	local html = fs.read(outPath)
+	test.falsy(html:find("__DATA__",   1, true))
+	test.falsy(html:find("__TITLE__",  1, true))
+	test.falsy(html:find("__MS__",     1, true))
+end)
+
+test.it("write: output is valid HTML with embedded JSON data", function()
+	local outPath = path.join(tmpBase, "valid.html")
+	fg.write({ ["outer;inner"] = 7 }, 7, 10, outPath)
+	local html = fs.read(outPath)
+	test.truthy(html:find("<!DOCTYPE html>", 1, true))
+	test.truthy(html:find("var D={",         1, true))
+	test.truthy(html:find("var D=.*MS=10",   1, false)) -- MS substituted
+end)
+
+test.it("write: title appears in the HTML output", function()
+	local outPath = path.join(tmpBase, "titled.html")
+	fg.write({ ["x"] = 1 }, 1, 10, outPath, "My Cool Script")
+	local html = fs.read(outPath)
+	test.truthy(html:find("My Cool Script", 1, true))
+end)
+
+test.it("write: JSON data contains the expected root node name", function()
+	local outPath = path.join(tmpBase, "rootname.html")
+	fg.write({ ["bench;inner"] = 4 }, 4, 10, outPath, "myscript")
+	local html = fs.read(outPath)
+	-- root is named after the title; "bench" and "inner" should be child nodes
+	test.truthy(html:find('"n":"myscript"', 1, true))
+	test.truthy(html:find('"n":"bench"',    1, true))
+	test.truthy(html:find('"n":"inner"',    1, true))
+end)
+
+test.it("write: handles percent signs in node names without corrupting output", function()
+	-- A % in a function name or path must not break Lua gsub replacement strings
+	local outPath = path.join(tmpBase, "percent.html")
+	local ok = fg.write({ ["fn_50%_done"] = 2 }, 2, 10, outPath)
+	test.truthy(ok)
+	local html = fs.read(outPath)
+	test.truthy(html:find("fn_50", 1, true))
+	test.falsy(html:find("__DATA__", 1, true))
+end)
+
+-- ── runtime: profile option ───────────────────────────────────────────────────
+
+test.it("executeFile with profile=true succeeds and returns ok", function()
+	local scriptPath = path.join(tmpBase, "prof.lua")
+	fs.write(scriptPath, [[
+		local s = 0
+		for i = 1, 500000 do s = s + i end
+		return s
+	]])
+	local ok, err = lde.runtime.executeFile(scriptPath, { profile = true })
+	test.truthy(ok)
+end)
+
+test.it("executeString with profile=true succeeds", function()
+	local ok, err = lde.runtime.executeString([[
+		local s = 0
+		for i = 1, 300000 do s = s + i end
+	]], { profile = true })
+	test.truthy(ok)
+end)
+
+-- ── runtime: flamegraph option ────────────────────────────────────────────────
+
+test.it("executeFile with flamegraph path writes an HTML file", function()
+	local scriptPath = path.join(tmpBase, "fg_script.lua")
+	local outPath    = path.join(tmpBase, "fg_out.html")
+	fs.write(scriptPath, [[
+		local s = 0
+		for i = 1, 1000000 do s = s + i end
+		return s
+	]])
+	local ok, err = lde.runtime.executeFile(scriptPath, { flamegraph = outPath })
+	test.truthy(ok)
+	-- File may or may not exist if no samples were collected (fast machine / CI);
+	-- if it does exist it must be valid HTML with no placeholders.
+	if fs.exists(outPath) then
+		local html = fs.read(outPath)
+		test.truthy(html:find("<!DOCTYPE html>", 1, true))
+		test.falsy(html:find("__DATA__",  1, true))
+		test.falsy(html:find("__MS__",    1, true))
+		test.falsy(html:find("__TITLE__", 1, true))
+	end
+end)
+
+test.it("executeFile with profile=true and flamegraph path both work together", function()
+	local scriptPath = path.join(tmpBase, "both_script.lua")
+	local outPath    = path.join(tmpBase, "both_out.html")
+	fs.write(scriptPath, [[
+		local s = 0
+		for i = 1, 1000000 do s = s + i end
+		return s
+	]])
+	local ok = lde.runtime.executeFile(scriptPath, {
+		profile   = true,
+		flamegraph = outPath,
+	})
+	test.truthy(ok)
+end)
+
+test.it("executeFile with flamegraph: no crash when script errors", function()
+	local scriptPath = path.join(tmpBase, "fg_error.lua")
+	local outPath    = path.join(tmpBase, "fg_error_out.html")
+	fs.write(scriptPath, [[
+		local s = 0
+		for i = 1, 200000 do s = s + i end
+		error("intentional error after work")
+	]])
+	local ok, err = lde.runtime.executeFile(scriptPath, { flamegraph = outPath })
+	test.falsy(ok)      -- script errored
+	test.truthy(err)    -- error message is propagated
+	-- profiler must have been stopped cleanly (no crash, no hang)
+end)

--- a/packages/lde/src/commands/run.lua
+++ b/packages/lde/src/commands/run.lua
@@ -12,6 +12,9 @@ local function run(args)
 	local scriptArgs ---@type string[]
 	local name = nil ---@type string?
 	local watch = args:flag("watch")
+	local profile = args:flag("profile")
+	local flamegraph = args:option("flamegraph")
+	if not flamegraph and args:flag("flamegraph") then flamegraph = "profile.html" end
 
 	local dash, dashPos = args:flag("")
 	if dash then
@@ -32,7 +35,9 @@ local function run(args)
 					args = scriptArgs,
 					cwd = env.cwd(),
 					packagePath = "",
-					packageCPath = ""
+					packageCPath = "",
+					profile = profile,
+					flamegraph = flamegraph
 				})
 				if not ok then
 					error("Failed to run script: " .. (err or "Script exited with a non-zero exit code"))
@@ -52,7 +57,7 @@ local function run(args)
 		if name and scripts and scripts[name] then
 			ok, err = pkg:runScript(name)
 		else
-			ok, err = pkg:runFile(name, scriptArgs)
+			ok, err = pkg:runFile(name, scriptArgs, nil, nil, profile, flamegraph)
 		end
 
 		if not ok then
@@ -74,6 +79,8 @@ local function run(args)
 	ansi.printf("{cyan}Watching %s for changes...\n", watchDir)
 
 	local spawnArgs = { "run" }
+	if profile then spawnArgs[#spawnArgs + 1] = "--profile" end
+	if flamegraph then spawnArgs[#spawnArgs + 1] = "--flamegraph=" .. flamegraph end
 	if name then spawnArgs[#spawnArgs + 1] = name end
 	if #scriptArgs > 0 then
 		spawnArgs[#spawnArgs + 1] = "--"

--- a/packages/lde/src/init.lua
+++ b/packages/lde/src/init.lua
@@ -77,6 +77,7 @@ local ansi = require("ansi")
 local clap = require("clap")
 local env = require("env")
 local fs = require("fs")
+local path = require("path")
 
 local lde = require("lde-core")
 
@@ -91,6 +92,20 @@ end
 lde.verbose = true
 
 local args = clap.parse({ ... })
+
+local cwdOverride = args:option("cwd") or args:short("C")
+if cwdOverride then
+	local requestedCwd = path.resolve(env.cwd(), cwdOverride)
+	if not fs.isdir(requestedCwd) then
+		ansi.printf("{red}Error: Directory does not exist: %s", requestedCwd)
+		os.exit(1)
+	end
+
+	if not env.chdir(requestedCwd) then
+		ansi.printf("{red}Error: Failed to change directory: %s", requestedCwd)
+		os.exit(1)
+	end
+end
 
 local treeOverride = args:option("tree")
 if treeOverride then

--- a/packages/lde/tests/main.test.lua
+++ b/packages/lde/tests/main.test.lua
@@ -78,6 +78,53 @@ test.it("--tree overrides the global lde directory", function()
 	test.truthy(fs.exists(path.join(tmpTree, "git")))
 end)
 
+test.it("-C changes the working directory before loose-file resolution", function()
+	local tmpDir = path.join(env.tmpdir(), "lde-cli-cwd-short")
+	local pkgDir = path.join(tmpDir, "pkg")
+	fs.rmdir(tmpDir)
+	fs.mkdir(tmpDir)
+	fs.mkdir(pkgDir)
+	fs.write(path.join(pkgDir, "hello.lua"), 'io.write("cwd-short")')
+
+	local ok, out = ldecli({ "-C", "pkg", "hello.lua" }, tmpDir)
+	test.truthy(ok)
+	test.includes(out, "cwd-short")
+
+	fs.rmdir(tmpDir)
+end)
+
+test.it("--cwd changes the working directory before package resolution", function()
+	local tmpDir = path.join(env.tmpdir(), "lde-cli-cwd-long")
+	local pkgDir = path.join(tmpDir, "pkg")
+	fs.rmdir(tmpDir)
+	fs.mkdir(tmpDir)
+	fs.mkdir(pkgDir)
+	fs.mkdir(path.join(pkgDir, "src"))
+	fs.write(path.join(pkgDir, "src", "init.lua"), 'io.write("cwd-long")')
+	fs.write(path.join(pkgDir, "lde.json"), json.encode({
+		name = "cwd-long",
+		version = "0.1.0"
+	}))
+
+	local ok, out = ldecli({ "--cwd", "pkg", "run" }, tmpDir)
+	test.truthy(ok)
+	test.includes(out, "cwd-long")
+
+	fs.rmdir(tmpDir)
+end)
+
+test.it("--cwd errors when the target directory does not exist", function()
+	local tmpDir = path.join(env.tmpdir(), "lde-cli-cwd-missing")
+	fs.rmdir(tmpDir)
+	fs.mkdir(tmpDir)
+
+	local ok, out = ldecli({ "--cwd", "missing", "--version" }, tmpDir)
+	test.falsy(ok)
+	test.includes(out, "Directory does not exist")
+
+	fs.rmdir(tmpDir)
+end)
+
 -- TODO: re-enable once a nightly build with TMPDIR set in the Android Docker run is available
 test.skipIf(env.var("ANDROID_ROOT") ~= nil)("lde <script> <args> passes positional args to the script", function()
 	local script = path.join(env.tmpdir(), "lde-argtest.lua")

--- a/packages/lde/tests/main.test.lua
+++ b/packages/lde/tests/main.test.lua
@@ -31,8 +31,10 @@ test.it("should not ignore --git in ldx", function()
 	fs.rmdir(repoDir)
 end)
 
--- TODO: re-enable once a nightly build with TMPDIR set in the Android Docker run is available
-test.skipIf(env.var("ANDROID_ROOT") ~= nil)("lde test skips packages with no tests/ directory", function()
+-- TODO: Figure out why android struggles with cli tests
+local isAndroid = env.var("ANDROID_ROOT") ~= nil
+
+test.skipIf(isAndroid)("lde test skips packages with no tests/ directory", function()
 	local tmpDir = path.join(env.tmpdir(), "lde-test-skip-test")
 	fs.rmdir(tmpDir)
 	fs.mkdir(tmpDir)
@@ -78,7 +80,7 @@ test.it("--tree overrides the global lde directory", function()
 	test.truthy(fs.exists(path.join(tmpTree, "git")))
 end)
 
-test.it("-C changes the working directory before loose-file resolution", function()
+test.skipIf(isAndroid)("-C changes the working directory before loose-file resolution", function()
 	local tmpDir = path.join(env.tmpdir(), "lde-cli-cwd-short")
 	local pkgDir = path.join(tmpDir, "pkg")
 	fs.rmdir(tmpDir)
@@ -93,7 +95,7 @@ test.it("-C changes the working directory before loose-file resolution", functio
 	fs.rmdir(tmpDir)
 end)
 
-test.it("--cwd changes the working directory before package resolution", function()
+test.skipIf(isAndroid)("--cwd changes the working directory before package resolution", function()
 	local tmpDir = path.join(env.tmpdir(), "lde-cli-cwd-long")
 	local pkgDir = path.join(tmpDir, "pkg")
 	fs.rmdir(tmpDir)


### PR DESCRIPTION
Now you can do `lde run --profile` to get a basic profiling output, or `lde run --flamegraph` for a recursive comprehensive flamegraph.

This is all powered by luajit's `jit.profile` for accuracy and to not mess with performance.